### PR TITLE
Add listEpicStories endpoint + tests

### DIFF
--- a/src/__tests__/Client-tests.ts
+++ b/src/__tests__/Client-tests.ts
@@ -235,4 +235,128 @@ describe('#Client', () => {
       expect(requests).toMatchSnapshot();
     });
   });
+
+  describe('.listEpics', () => {
+    it('list all epics without description', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
+
+      await client.listEpics();
+
+      expect(requests).toMatchSnapshot();
+    });
+
+    it('list all epics with description', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
+
+      await client.listEpics(true);
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
+
+  describe('.getEpic', () => {
+    it('requests a single epic', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { id: 1234 } });
+      });
+
+      await client.getEpic(1234);
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
+
+  describe('.createEpic', () => {
+    it('creates a new epic', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { name: 'test' } });
+      });
+
+      await client.createEpic({ name: 'test' });
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
+
+  describe('.updateEpic', () => {
+    it('updates an existing epic', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: { name: 'test' } });
+      });
+
+      await client.updateEpic(1234, { name: 'test' });
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
+
+  describe('.deleteEpic', () => {
+    it('deletes an existing epic', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
+
+      await client.deleteEpic(1234);
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
+
+  describe('.listEpicStories', () => {
+    it('list all stories in an epic without description', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
+
+      await client.listEpicStories(1234);
+
+      expect(requests).toMatchSnapshot();
+    });
+
+    it('list all stories in an epic with description', async () => {
+      const requests:
+        | any[]
+        | { uri: string; method?: string; body?: Record<string, any> }[] = [];
+      const client = createTestClient((request) => {
+        requests.push(request);
+        return Promise.resolve({ status: 200, body: {} });
+      });
+
+      await client.listEpicStories(1234, true);
+
+      expect(requests).toMatchSnapshot();
+    });
+  });
 });

--- a/src/__tests__/__snapshots__/Client-tests.ts.snap
+++ b/src/__tests__/__snapshots__/Client-tests.ts.snap
@@ -12,6 +12,18 @@ Array [
 ]
 `;
 
+exports[`#Client .createEpic creates a new epic 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "name": "test",
+    },
+    "method": "POST",
+    "uri": "http://localhost:4001/api/v3/epics",
+  },
+]
+`;
+
 exports[`#Client .createLabel create a label 1`] = `
 Array [
   Object {
@@ -61,6 +73,16 @@ Array [
 ]
 `;
 
+exports[`#Client .deleteEpic deletes an existing epic 1`] = `
+Array [
+  Object {
+    "body": undefined,
+    "method": "DELETE",
+    "uri": "http://localhost:4001/api/v3/epics/1234",
+  },
+]
+`;
+
 exports[`#Client .deleteProject deletes a existing project 1`] = `
 Array [
   Object {
@@ -93,6 +115,16 @@ Array [
 ]
 `;
 
+exports[`#Client .getEpic requests a single epic 1`] = `
+Array [
+  Object {
+    "body": undefined,
+    "method": undefined,
+    "uri": "http://localhost:4001/api/v3/epics/1234",
+  },
+]
+`;
+
 exports[`#Client .getProject requests a single project 1`] = `
 Array [
   Object {
@@ -109,6 +141,54 @@ Array [
     "body": undefined,
     "method": undefined,
     "uri": "http://localhost:4001/api/v3/story-links/1234",
+  },
+]
+`;
+
+exports[`#Client .listEpicStories list all stories in an epic with description 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "includes_description": true,
+    },
+    "method": "GET",
+    "uri": "http://localhost:4001/api/v3/epics/1234/stories",
+  },
+]
+`;
+
+exports[`#Client .listEpicStories list all stories in an epic without description 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "includes_description": false,
+    },
+    "method": "GET",
+    "uri": "http://localhost:4001/api/v3/epics/1234/stories",
+  },
+]
+`;
+
+exports[`#Client .listEpics list all epics with description 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "includes_description": true,
+    },
+    "method": "GET",
+    "uri": "http://localhost:4001/api/v3/epics",
+  },
+]
+`;
+
+exports[`#Client .listEpics list all epics without description 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "includes_description": false,
+    },
+    "method": "GET",
+    "uri": "http://localhost:4001/api/v3/epics",
   },
 ]
 `;
@@ -141,6 +221,18 @@ Array [
     },
     "method": "PUT",
     "uri": "http://localhost:4001/api/v3/stories/12/comments/5",
+  },
+]
+`;
+
+exports[`#Client .updateEpic updates an existing epic 1`] = `
+Array [
+  Object {
+    "body": Object {
+      "name": "test",
+    },
+    "method": "PUT",
+    "uri": "http://localhost:4001/api/v3/epics/1234",
   },
 ]
 `;

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,8 +168,10 @@ class Client<RequestType, ResponseType> {
   }
 
   /** */
-  listEpics(): Promise<Array<Epic>> {
-    return this.listResource('epics');
+  listEpics(includesDescription?: boolean): Promise<Array<Epic>> {
+    return this.listResource('epics', {
+      includes_description: Boolean(includesDescription),
+    });
   }
 
   /** */
@@ -190,6 +192,15 @@ class Client<RequestType, ResponseType> {
   /** */
   deleteEpic(epicID: ID): Promise<Record<string, unknown>> {
     return this.deleteResource(`epics/${epicID}`);
+  }
+
+  listEpicStories(
+    epicID: ID,
+    includesDescription?: boolean,
+  ): Promise<Array<Story>> {
+    return this.listResource(`epics/${epicID}/stories`, {
+      includes_description: Boolean(includesDescription),
+    });
   }
 
   /** */


### PR DESCRIPTION
This PR
- adds support for the `listEpicStories` endpoint
- updates the `listEpics` endpoint to include optional params
- adds tests for the existing `epic` methods